### PR TITLE
Avoid unnecessary retracing

### DIFF
--- a/sup3r/models/base.py
+++ b/sup3r/models/base.py
@@ -132,7 +132,7 @@ class Sup3rGan(AbstractSup3rGan):
 
     def load_network(self, model, name):
         """Load a CustomNetwork object from hidden layers config, .json file
-        config, or .pkl file saved pre=trained model.
+        config, or .pkl file saved pre-trained model.
 
         Parameters
         ----------

--- a/sup3r/models/base.py
+++ b/sup3r/models/base.py
@@ -1181,7 +1181,6 @@ class Sup3rGan(AbstractSup3rGan):
 
         return loss_disc
 
-    @tf.function
     def calc_loss(self, hi_res_true, hi_res_gen, weight_gen_advers=0.001,
                   train_gen=True, train_disc=False):
         """Calculate the GAN loss function using generated and true high


### PR DESCRIPTION
The `calc_loss` function should not be a `tf.function` since its behavior changes depending on whether discriminator or generator, or both are trained.
With the `tf.function` on, function retracing occurs (we see messages like `WARNING:tensorflow:5 out of the last 18 calls to <function Sup3rGan.calc_loss at 0x7facf82f8290> triggered tf.function retracing...`). 

With `tf.function` off, no retracing occurs. I could also see a small speed up when running on my machine.

To reproduce results, run the following snippet in `tests/`

```
from test_train_gan import *


import time
time_start = time.time()
test_train_st_weight_update(n_epoch=5, log=True)
time_end = time.time()
print("Total Time = %g" % (time_end - time_start))

```