### PR TITLE
Defining some minimum versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,10 +5,10 @@ NREL-gaps>=0.6.0
 NREL-farms>=1.0.4
 google-auth-oauthlib==0.5.3
 pytest>=5.2
-pillow
+pillow>=10.0
 tensorflow>2.4
-xarray
+xarray>=2023.0
 netCDF4==1.5.8
-dask
-sphinx
-pandas
+dask>=2022.0
+sphinx>=7.0
+pandas>=2.0


### PR DESCRIPTION
These are the versions that I could install with Python-3.8. This info might be helpful to keep track.

Can you confirm that these versions don't conflict with your local & HPC environments?