### PR TITLE
Fix documentation, requires tags to figure out version

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -8,7 +8,10 @@ jobs:
   make-pages:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - name: select python version
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -15,7 +15,7 @@ jobs:
       - name: select python version
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: '3.10'
           cache: 'pip'
       - name: install dependencies
         run: |

--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -13,9 +13,10 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
       - name: select python version
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
+          cache: 'pip'
       - name: install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -19,10 +19,7 @@ jobs:
       - name: install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .
-          python -m pip install sphinx
-          python -m pip install sphinx_rtd_theme
-          python -m pip install sphinx-click
+          python -m pip install .[doc]
       - name: build documentation
         run: |
           cd docs


### PR DESCRIPTION
When checking repository, include tags history to allow figuring out the current package version.

Check the version shown at https://nrel.github.io/sup3r/ to understand the issue.