### PR TITLE
Pipeline requires explicit arguments for QuantileDeltaMappingCorrection

### DIFF
--- a/sup3r/bias/bias_transforms.py
+++ b/sup3r/bias/bias_transforms.py
@@ -497,7 +497,7 @@ def local_qdm_bc(data: np.array,
         spatial_slice = (lr_padded_slice[0], lr_padded_slice[1])
         base = base[spatial_slice]
         bias = bias[spatial_slice]
-        bias_fut = bias[spatial_slice]
+        bias_fut = bias_fut[spatial_slice]
 
     if no_trend:
         mf = None

--- a/sup3r/preprocessing/data_handling/base.py
+++ b/sup3r/preprocessing/data_handling/base.py
@@ -1331,7 +1331,8 @@ class DataHandler(FeatureHandler, InputMixIn, TrainingPrepMixIn):
                bc_files,
                reference_feature,
                relative=True,
-               threshold=0.1):
+               threshold=0.1,
+               no_trend=False):
         """Bias Correction using Quantile Delta Mapping
 
         Bias correct this DataHandler's data with Quantile Delta Mapping. The
@@ -1361,6 +1362,15 @@ class DataHandler(FeatureHandler, InputMixIn, TrainingPrepMixIn):
             Nearest neighbor euclidean distance threshold. If the DataHandler
             coordinates are more than this value away from the bias correction
             lat/lon, an error is raised.
+        no_trend: bool, default=False
+            An option to ignore the trend component of the correction, thus
+            resulting in an ordinary Quantile Mapping, i.e. corrects the bias
+            by comparing the distributions of the biased dataset with a
+            reference datasets. See ``params_mf`` of
+            :class:`rex.utilities.bc_utils.QuantileDeltaMapping`.
+            Note that this assumes that "bias_{feature}_params"
+            (``params_mh``) is the data distribution representative for the
+            target data.
         """
 
         if isinstance(bc_files, str):
@@ -1378,7 +1388,8 @@ class DataHandler(FeatureHandler, InputMixIn, TrainingPrepMixIn):
                                                    feature,
                                                    bias_fp=fp,
                                                    threshold=threshold,
-                                                   relative=relative)
+                                                   relative=relative,
+                                                   no_trend=no_trend)
                 completed.append(feature)
 
 

--- a/tests/bias/test_qdm_bias_correction.py
+++ b/tests/bias/test_qdm_bias_correction.py
@@ -359,3 +359,20 @@ def test_bc_trend_same_hist(tmp_path, fp_fut_cc, dist_params):
 
     idx = ~(np.isnan(original) | np.isnan(corrected))
     assert np.allclose(corrected[idx], original[idx])
+
+
+def test_fwd_integration():
+
+    bc_strat = ForwardPassStrategy(
+            input_files,
+            model_kwargs={'model_dir': out_dir},
+            fwp_chunk_shape=fwp_chunk_shape,
+            spatial_pad=0, temporal_pad=0,
+            input_handler_kwargs=dict(target=target, shape=shape,
+                                      temporal_slice=temporal_slice,
+                                      worker_kwargs=dict(max_workers=1)),
+            out_pattern=os.path.join(td, 'out_{file_id}.nc'),
+            worker_kwargs=dict(max_workers=1),
+            input_handler='DataHandlerNCforCC',
+            bias_correct_method='local_linear_bc',
+            bias_correct_kwargs=bias_correct_kwargs)


### PR DESCRIPTION
@grantbuster raised the point that the pipeline system requires explicit argument to orchestrate the inputs.