### PR TITLE
Explicit keyword argument

### DIFF
--- a/sup3r/pipeline/forward_pass.py
+++ b/sup3r/pipeline/forward_pass.py
@@ -1578,7 +1578,7 @@ class ForwardPass:
                                  feature, idf, method, feature_kwargs))
 
                 data[..., idf] = method(data[..., idf],
-                                        lat_lon,
+                                        lat_lon=lat_lon,
                                         **feature_kwargs)
 
         return data


### PR DESCRIPTION
The forward pass uses `lat_lon` as a positional argument, which caused an error in the PresRat implementation. Is there a good reason to don't be explicit here by using a keyword argument?

I split this from #215 to be sure that this is not breaking anything else.