### PR TITLE
Bug fix on GCM clearsky ratio

### DIFF
--- a/sup3r/models/surface.py
+++ b/sup3r/models/surface.py
@@ -760,7 +760,18 @@ class SurfaceSpatialMetModel(LinearInterp):
         w_delta_topo : float
             Weight for the delta-topography feature for the relative humidity
             linear regression model.
+        regr : sklearn.LinearRegression
+            Trained regression object that predicts regr(x) = y
+        x : np.ndarray
+            2D array of shape (n, 2) where n is the number of observations
+            being trained on and axis=1 is 1) the True high-res temperature
+            minus the interpolated temperature and 2) the True high-res topo
+            minus the interpolate topo.
+        y : np.ndarray
+            2D array of shape (n,) that represents the true high-res humidity
+            minus the interpolated humidity
         """
+
         self._input_resolution = input_resolution
         assert len(true_hr_temp.shape) == 3, 'Bad true_hr_temp shape'
         assert len(true_hr_rh.shape) == 3, 'Bad true_hr_rh shape'
@@ -799,7 +810,7 @@ class SurfaceSpatialMetModel(LinearInterp):
         x = np.vstack((x1.flatten(), x2.flatten())).T
         y = (true_hr_rh - interp_hr_rh).flatten()
 
-        regr = linear_model.LinearRegression()
+        regr = linear_model.LinearRegression(fit_intercept=False)
         regr.fit(x, y)
         if np.abs(regr.intercept_) > 1e-6:
             msg = (
@@ -813,4 +824,4 @@ class SurfaceSpatialMetModel(LinearInterp):
 
         w_delta_temp, w_delta_topo = regr.coef_[0], regr.coef_[1]
 
-        return w_delta_temp, w_delta_topo
+        return w_delta_temp, w_delta_topo, regr, x, y

--- a/sup3r/preprocessing/data_handlers/nc_cc.py
+++ b/sup3r/preprocessing/data_handlers/nc_cc.py
@@ -37,6 +37,7 @@ class DataHandlerNCforCC(BaseNCforCC):
         nsrdb_source_fp=None,
         nsrdb_agg=1,
         nsrdb_smoothing=0,
+        scale_clearsky_ghi=True,
         **kwargs,
     ):
         """
@@ -61,6 +62,12 @@ class DataHandlerNCforCC(BaseNCforCC):
             clearsky_ghi from high-resolution nsrdb source data. This is
             typically done because spatially aggregated nsrdb data is still
             usually rougher than CC irradiance data.
+        scale_clearsky_ghi : bool
+            Flag to scale the NSRDB clearsky ghi so that the maximum value
+            matches the GCM rsds maximum value per spatial pixel. This is
+            useful when calculating "clearsky_ratio" so that there are not an
+            unrealistic number of 1 values if the maximum NSRDB clearsky_ghi is
+            much lower than the GCM values
         kwargs : list
             Same optional keyword arguments as parent class.
         """
@@ -68,6 +75,7 @@ class DataHandlerNCforCC(BaseNCforCC):
         self._nsrdb_agg = nsrdb_agg
         self._nsrdb_smoothing = nsrdb_smoothing
         self._features = features
+        self._scale_clearsky_ghi = scale_clearsky_ghi
         super().__init__(file_paths=file_paths, features=features, **kwargs)
 
     _signature_objs = (__init__, BaseNCforCC)
@@ -78,11 +86,13 @@ class DataHandlerNCforCC(BaseNCforCC):
         rasterized data, which will then be used when the :class:`Deriver` is
         called."""
         cs_feats = ['clearsky_ratio', 'clearsky_ghi']
-        need_ghi = any(
+        need_cs_ghi = any(
             f in self._features and f not in self.rasterizer for f in cs_feats
         )
-        if need_ghi:
+        if need_cs_ghi:
             self.rasterizer.data['clearsky_ghi'] = self.get_clearsky_ghi()
+        if need_cs_ghi and self._scale_clearsky_ghi:
+            self.scale_clearsky_ghi()
 
     def run_input_checks(self):
         """Run checks on the files provided for extracting clearsky_ghi. Make
@@ -183,28 +193,21 @@ class DataHandlerNCforCC(BaseNCforCC):
             )
         )
 
-        cs_ghi = (
-            res.data[['clearsky_ghi']]
-            .isel(
-                {
-                    Dimension.FLATTENED_SPATIAL: i.flatten(),
-                    Dimension.TIME: t_slice,
-                }
-            )
-            .coarsen({Dimension.FLATTENED_SPATIAL: self._nsrdb_agg})
-            .mean()
-        )
-        time_freq = float(
-            mode(
-                (ti_nsrdb[1:] - ti_nsrdb[:-1]).seconds / 3600, keepdims=False
-            ).mode
-        )
+        # spatial coarsening from NSRDB to GCM
+        cs_ghi = res.data[['clearsky_ghi']]
+        dims = i.flatten()
+        dims = {Dimension.FLATTENED_SPATIAL: dims, Dimension.TIME: t_slice}
+        cs_ghi = cs_ghi.isel(dims)
+        cs_ghi = cs_ghi.coarsen({Dimension.FLATTENED_SPATIAL: self._nsrdb_agg})
+        cs_ghi = cs_ghi.mean()
 
+        # temporal coarsening from NSRDB to daily average
+        time_freq = (ti_nsrdb[1:] - ti_nsrdb[:-1]).seconds / 3600
+        time_freq = float(mode(time_freq, keepdims=False).mode)
         cs_ghi = cs_ghi.coarsen({Dimension.TIME: int(24 // time_freq)}).mean()
-        lat_idx, lon_idx = (
-            np.arange(self.rasterizer.grid_shape[0]),
-            np.arange(self.rasterizer.grid_shape[1]),
-        )
+
+        lat_idx = np.arange(self.rasterizer.grid_shape[0])
+        lon_idx = np.arange(self.rasterizer.grid_shape[1])
         ind = pd.MultiIndex.from_product(
             (lat_idx, lon_idx), names=Dimension.dims_2d()
         )
@@ -213,19 +216,33 @@ class DataHandlerNCforCC(BaseNCforCC):
         )
 
         cs_ghi = cs_ghi.transpose(*Dimension.dims_3d())
-
         cs_ghi = cs_ghi['clearsky_ghi'].data
-        if cs_ghi.shape[-1] < len(self.rasterizer.time_index):
-            n = int(
-                da.ceil(len(self.rasterizer.time_index) / cs_ghi.shape[-1])
-            )
-            cs_ghi = da.repeat(cs_ghi, n, axis=2)
 
-        cs_ghi = cs_ghi[..., : len(self.rasterizer.time_index)]
+        # concatenate multiple years, need to consider leap years explicitly
+        # so decadal timeseries dont get shifted
+        multi_year = []
+        if cs_ghi.shape[-1] < len(self.rasterizer.time_index):
+            for year in self.rasterizer.time_index.year.unique():
+                n = (self.rasterizer.time_index.year == year).sum()
+                multi_year.append(cs_ghi[..., :n])
+
+        cs_ghi = da.concatenate(multi_year, axis=-1)
+        cs_ghi = cs_ghi[..., :len(self.rasterizer.time_index)]
 
         self.run_wrap_checks(cs_ghi)
 
         return cs_ghi
+
+    def scale_clearsky_ghi(self):
+        """Method to scale the NSRDB clearsky ghi so that the maximum value
+        matches the GCM rsds maximum value per spatial pixel. This is useful
+        when calculating "clearsky_ratio" so that there are not an unrealistic
+        number of 1 values if the maximum NSRDB clearsky_ghi is much lower than
+        the GCM values"""
+        ghi_max = self.rasterizer.data['rsds'].max(dim='time')
+        cs_max = self.rasterizer.data['clearsky_ghi'].max(dim='time')
+        scale = ghi_max / cs_max
+        self.rasterizer.data['clearsky_ghi'] *= scale
 
 
 class DataHandlerNCforCCwithPowerLaw(DataHandlerNCforCC):

--- a/tests/data_handlers/test_dh_nc_cc.py
+++ b/tests/data_handlers/test_dh_nc_cc.py
@@ -225,6 +225,7 @@ def test_solar_cc(agg):
         target=target,
         shape=shape,
         time_slice=slice(0, 1),
+        scale_clearsky_ghi=True,
     )
 
     cs_ratio = handler.data['clearsky_ratio']
@@ -232,9 +233,8 @@ def test_solar_cc(agg):
     cs_ghi = handler.data['clearsky_ghi']
     cs_ratio_truth = ghi / cs_ghi
 
-    assert cs_ratio.max() < 1
-    assert cs_ratio.min() > 0
-    assert (ghi < cs_ghi).all()
+    assert cs_ratio.max() <= 1
+    assert cs_ratio.min() >= 0
     assert np.allclose(cs_ratio, cs_ratio_truth)
 
     with Resource(nsrdb_source_fp) as res:
@@ -247,5 +247,6 @@ def test_solar_cc(agg):
         for j in range(4):
             test_coord = handler.lat_lon[i, j]
             _, inn = tree.query(test_coord, k=agg)
-
-            assert np.allclose(cs_ghi_true[0:48, inn].mean(), cs_ghi[i, j])
+            true = cs_ghi_true[0:48, inn].mean()
+            scaled_true = true * handler._cs_ghi_scale[i, j]
+            assert np.allclose(scaled_true, cs_ghi[i, j])


### PR DESCRIPTION
@bnb32, possibly a bit premature as i haven't tested thoroughly yet, but since kestrel is down and i know you're bored i thought i'd submit this for review now. 

Main fix is that `da.repeat` does not do what we think it does for multi year solar timeseries (see lines referenced below). We need to stack multiple years of the NSRDB clearsky ghi but da.repeat does [1, 2, 3] -> [1, 1, 2, 2, 3, 3] so you get one giant annual cycle which results in a lot of ratio=1 values at the edges. Leap days also matter... if we do nyears*366 for nyears>10 we end up with a growing shift in the later years. This matters a lot for the 40-year record we analyze for bias correction. 

https://github.com/NREL/sup3r/compare/main...gb/csratio#diff-d97151971c312b63001f37eafc4f5fac2020d7b0a7421d7b3e4adfa1bf7d1cebR223-R229