### PR TITLE
enable multiple exo source files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -336,3 +336,4 @@ hvplot = ">=0.10"
 [tool.pytest_env]
 CUDA_VISIBLE_DEVICES = "-1"
 TF_ENABLE_ONEDNN_OPTS = "0"
+TF_FORCE_GPU_ALLOW_GROWTH = true

--- a/sup3r/models/utilities.py
+++ b/sup3r/models/utilities.py
@@ -70,8 +70,8 @@ class TrainingSession:
             model_thread.join()
             sys.exit()
 
-        logger.info('Finished training')
         model_thread.join()
+        logger.info('Finished training')
 
 
 class TensorboardMixIn:

--- a/sup3r/pipeline/strategy.py
+++ b/sup3r/pipeline/strategy.py
@@ -141,7 +141,7 @@ class ForwardPassStrategy:
         for the handler which opens the
         exogenous data. e.g.::
             {'topography': {
-                'source_file': ...,
+                'source_files': ...,
                 'input_files': ...,
                 'input_handler_kwargs': {'target': ..., 'shape': ...}}}
     bias_correct_method : str | None

--- a/sup3r/pipeline/strategy.py
+++ b/sup3r/pipeline/strategy.py
@@ -589,10 +589,14 @@ class ForwardPassStrategy:
                 input_handler_kwargs = exo_kwargs.get(
                     'input_handler_kwargs', {}
                 )
+                source_handler_kwargs = exo_kwargs.get(
+                    'source_handler_kwargs', {}
+                )
                 input_handler_kwargs['target'] = self.input_handler.target
                 input_handler_kwargs['shape'] = self.input_handler.grid_shape
                 input_handler_kwargs['time_slice'] = self.padded_time_slice
                 exo_kwargs['input_handler_kwargs'] = input_handler_kwargs
+                exo_kwargs['source_handler_kwargs'] = source_handler_kwargs
                 exo_kwargs = get_class_kwargs(ExoDataHandler, exo_kwargs)
                 exo_kwargs_list.append(exo_kwargs)
         return exo_kwargs_list

--- a/sup3r/preprocessing/data_handlers/exo.py
+++ b/sup3r/preprocessing/data_handlers/exo.py
@@ -309,14 +309,14 @@ class ExoDataHandler:
         Each step entry can also contain enhancement factors. e.g.::
         [{'model': 0, 'combine_type': 'input', 's_enhance': 1, 't_enhance': 1},
          {'model': 0, 'combine_type': 'layer', 's_enhance': 3, 't_enhance': 1}]
-    source_file : str
-        Filepath to source wtk, nsrdb, or netcdf file to get hi-res data from
+    source_files : str
+        Filepath to source wtk, nsrdb, or netcdf files to get hi-res data from
         which will be mapped to the enhanced grid of the file_paths input.
-        Pixels from this file will be mapped to their nearest low-res pixel in
-        the file_paths input. Accordingly, the input should be a significantly
-        higher resolution than file_paths. Warnings will be raised if the
-        low-resolution pixels in file_paths do not have unique nearest pixels
-        from this exo source data.
+        Pixels from these files will be mapped to their nearest low-res pixel
+        in the file_paths input. Accordingly, the input should be a
+        significantly higher resolution than file_paths. Warnings will be
+        raised if the low-resolution pixels in file_paths do not have unique
+        nearest pixels from this exo source data.
     input_handler_name : str
         data handler class used by the exo handler. Provide a string name to
         match a :class:`~sup3r.preprocessing.rasterizers.Rasterizer`. If None
@@ -326,6 +326,8 @@ class ExoDataHandler:
     input_handler_kwargs : dict | None
         Any kwargs for initializing the ``input_handler_name`` class used by
         the exo handler.
+    source_handler_kwargs : dict | None
+        Any kwargs for initializing the source handler (``Loader``).
     cache_dir : str | None
         Directory for storing cache data. Default is './exo_cache'. If None
         then no data will be cached.
@@ -335,18 +337,19 @@ class ExoDataHandler:
         be "auto". This is passed to ``.chunk()`` before returning exo data
         through ``.data`` attribute
     distance_upper_bound : float | None
-        Maximum distance to map high-resolution data from source_file to the
+        Maximum distance to map high-resolution data from source_files to the
         low-resolution file_paths input. None (default) will calculate this
-        based on the median distance between points in source_file
+        based on the median distance between points in source_files
     """
 
     file_paths: Union[str, list, pathlib.Path]
     feature: str
     model: Optional[Union['Sup3rGan', 'MultiStepGan']] = None
     steps: Optional[list] = None
-    source_file: Optional[str] = None
+    source_files: Optional[str] = None
     input_handler_name: Optional[str] = None
     input_handler_kwargs: Optional[dict] = None
+    source_handler_kwargs: Optional[dict] = None
     cache_dir: str = './exo_cache'
     chunks: Optional[Union[str, dict]] = 'auto'
     distance_upper_bound: Optional[int] = None
@@ -403,12 +406,13 @@ class ExoDataHandler:
         """Get exo rasterizer instance for given enhancement factors"""
         return ExoRasterizer(
             file_paths=self.file_paths,
-            source_file=self.source_file,
+            source_files=self.source_files,
             feature=self.feature,
             s_enhance=s_enhance,
             t_enhance=t_enhance,
             input_handler_name=self.input_handler_name,
             input_handler_kwargs=self.input_handler_kwargs,
+            source_handler_kwargs=self.source_handler_kwargs,
             cache_dir=self.cache_dir,
             chunks=self.chunks,
             distance_upper_bound=self.distance_upper_bound,

--- a/sup3r/preprocessing/loaders/__init__.py
+++ b/sup3r/preprocessing/loaders/__init__.py
@@ -18,7 +18,7 @@ class Loader:
 
     def __new__(cls, file_paths, **kwargs):
         """Override parent class to return type specific class based on
-        `source_file`"""
+        `source_files`"""
         SpecificClass = cls.TypeSpecificClasses[get_source_type(file_paths)]
         return SpecificClass(file_paths, **kwargs)
 

--- a/sup3r/preprocessing/loaders/__init__.py
+++ b/sup3r/preprocessing/loaders/__init__.py
@@ -3,14 +3,15 @@ data."""
 
 from typing import ClassVar
 
-from sup3r.preprocessing.utilities import composite_info, get_source_type
+from sup3r.preprocessing.base import Sup3rMeta
+from sup3r.preprocessing.utilities import get_source_type
 
 from .base import BaseLoader
 from .h5 import LoaderH5
 from .nc import LoaderNC
 
 
-class Loader:
+class Loader(BaseLoader, metaclass=Sup3rMeta):
     """`Loader` class which parses input file type and returns
     appropriate `TypeSpecificLoader`."""
 

--- a/sup3r/preprocessing/loaders/base.py
+++ b/sup3r/preprocessing/loaders/base.py
@@ -25,12 +25,14 @@ logger = logging.getLogger(__name__)
 
 
 class BaseLoader(Container, ABC):
-    """Base loader. "Loads" files so that a `.data` attribute provides access
+    """
+    Base loader. "Loads" files so that a `.data` attribute provides access
     to the data in the files as a dask array with shape (lats, lons, time,
     features). This object provides a `__getitem__` method that can be used by
     :class:`~sup3r.preprocessing.samplers.Sampler` objects to build batches or
     by :class:`~sup3r.preprocessing.rasterizers.Rasterizer` objects to derive /
-    extract specific features / regions / time_periods."""
+    extract specific features / regions / time_periods.
+    """
 
     BASE_LOADER: Callable = xr_open_mfdataset
 

--- a/sup3r/preprocessing/rasterizers/exo.py
+++ b/sup3r/preprocessing/rasterizers/exo.py
@@ -142,7 +142,7 @@ class BaseExoRasterizer(ABC):
         """Get the Loader object that handles the exogenous data file."""
         if self._source_handler is None:
             self._source_handler = Loader(
-                self.source_files, featuers=[self.feature],
+                self.source_files, features=[self.feature],
                 **get_class_kwargs(Loader, self.source_handler_kwargs),
             )
         return self._source_handler
@@ -435,7 +435,7 @@ class ObsRasterizer(BaseExoRasterizer):
         feat = self.feature.replace('_obs', '')
         if self._source_handler is None:
             self._source_handler = Loader(
-                self.source_files, featuers=[feat],
+                self.source_files, features=[feat],
                 **get_class_kwargs(Loader, self.source_handler_kwargs),
             )
         return self._source_handler

--- a/tests/docs/test_doc_automation.py
+++ b/tests/docs/test_doc_automation.py
@@ -14,6 +14,7 @@ from sup3r.preprocessing import (
     DataHandlerH5WindCC,
     DataHandlerNCforCC,
     ExoRasterizer,
+    Loader,
     Rasterizer,
     SamplerDC,
 )
@@ -30,7 +31,8 @@ from sup3r.preprocessing import (
         DataHandlerH5SolarCC,
         DataHandlerH5WindCC,
         Rasterizer,
-        ExoRasterizer
+        ExoRasterizer,
+        Loader
     ),
 )
 def test_full_docs(obj):

--- a/tests/forward_pass/test_forward_pass_exo.py
+++ b/tests/forward_pass/test_forward_pass_exo.py
@@ -103,7 +103,7 @@ def test_fwp_multi_step_model_topo_exoskip(input_files):
         exo_handler_kwargs = {
             'topography': {
                 'file_paths': input_files,
-                'source_file': pytest.FP_WTK,
+                'source_files': pytest.FP_WTK,
                 'target': target,
                 'shape': shape,
                 'cache_dir': td,
@@ -198,7 +198,7 @@ def test_fwp_multi_step_spatial_model_topo_noskip(input_files):
         exo_handler_kwargs = {
             'topography': {
                 'file_paths': input_files,
-                'source_file': pytest.FP_WTK,
+                'source_files': pytest.FP_WTK,
                 'target': target,
                 'shape': shape,
                 'cache_dir': td,
@@ -311,7 +311,7 @@ def test_fwp_multi_step_model_topo_noskip(input_files):
         exo_handler_kwargs = {
             'topography': {
                 'file_paths': input_files,
-                'source_file': pytest.FP_WTK,
+                'source_files': pytest.FP_WTK,
                 'target': target,
                 'shape': shape,
                 'cache_dir': td,
@@ -385,7 +385,7 @@ def test_fwp_single_step_sfc_model(input_files, plot=False):
         exo_handler_kwargs = {
             'topography': {
                 'file_paths': input_files,
-                'source_file': pytest.FP_WTK,
+                'source_files': pytest.FP_WTK,
                 'target': target,
                 'shape': shape,
                 'cache_dir': td,
@@ -512,7 +512,7 @@ def test_fwp_single_step_wind_hi_res_topo(input_files, plot=False):
         exo_handler_kwargs = {
             'topography': {
                 'file_paths': input_files,
-                'source_file': pytest.FP_WTK,
+                'source_files': pytest.FP_WTK,
                 'target': target,
                 'shape': shape,
                 'cache_dir': td,
@@ -629,7 +629,7 @@ def test_fwp_multi_step_wind_hi_res_topo(input_files, gen_config_with_topo):
         exo_handler_kwargs = {
             'topography': {
                 'file_paths': input_files,
-                'source_file': pytest.FP_WTK,
+                'source_files': pytest.FP_WTK,
                 'target': target,
                 'shape': shape,
                 'cache_dir': td,
@@ -705,7 +705,7 @@ def test_fwp_wind_hi_res_topo_plus_linear(input_files, gen_config_with_topo):
         exo_handler_kwargs = {
             'topography': {
                 'file_paths': input_files,
-                'source_file': pytest.FP_WTK,
+                'source_files': pytest.FP_WTK,
                 'target': target,
                 'shape': shape,
                 'cache_dir': td,
@@ -797,7 +797,7 @@ def test_fwp_multi_step_model_multi_exo(input_files):
         exo_handler_kwargs = {
             'topography': {
                 'file_paths': input_files,
-                'source_file': pytest.FP_WTK,
+                'source_files': pytest.FP_WTK,
                 'target': target,
                 'shape': shape,
                 'cache_dir': td,
@@ -990,7 +990,7 @@ def test_fwp_multi_step_exo_hi_res_topo_and_sza(
         exo_handler_kwargs = {
             'topography': {
                 'file_paths': input_files,
-                'source_file': pytest.FP_WTK,
+                'source_files': pytest.FP_WTK,
                 'target': target,
                 'shape': shape,
                 'cache_dir': td,

--- a/tests/forward_pass/test_forward_pass_obs.py
+++ b/tests/forward_pass/test_forward_pass_obs.py
@@ -161,14 +161,14 @@ def test_fwp_with_obs(
         exo_handler_kwargs = {
             'u_10m_obs': {
                 'file_paths': input_file,
-                'source_file': obs_file,
+                'source_files': obs_file,
                 'target': target,
                 'shape': shape,
                 'cache_dir': td,
             },
             'v_10m_obs': {
                 'file_paths': input_file,
-                'source_file': obs_file,
+                'source_files': obs_file,
                 'target': target,
                 'shape': shape,
                 'cache_dir': td,

--- a/tests/rasterizers/test_exo.py
+++ b/tests/rasterizers/test_exo.py
@@ -50,7 +50,7 @@ def test_exo_cache(feature):
         base = ExoDataHandler(
             pytest.FPS_GCM,
             feature,
-            source_file=fp_topo,
+            source_files=fp_topo,
             steps=steps,
             input_handler_kwargs={'target': TARGET, 'shape': SHAPE},
             input_handler_name='Rasterizer',
@@ -66,7 +66,7 @@ def test_exo_cache(feature):
         cache = ExoDataHandler(
             pytest.FPS_GCM,
             feature,
-            source_file=pytest.FP_WTK,
+            source_files=pytest.FP_WTK,
             steps=steps,
             input_handler_kwargs={'target': TARGET, 'shape': SHAPE},
             input_handler_name='Rasterizer',
@@ -173,7 +173,7 @@ def test_srl_extraction_h5(s_enhance):
 
         kwargs = {
             'file_paths': pytest.FP_WTK,
-            'source_file': fp_exo_srl,
+            'source_files': fp_exo_srl,
             'feature': 'srl',
             's_enhance': s_enhance,
             't_enhance': 1,
@@ -229,7 +229,7 @@ def test_topo_extraction_h5(s_enhance):
 
         kwargs = {
             'file_paths': pytest.FP_WTK,
-            'source_file': fp_exo_topo,
+            'source_files': fp_exo_topo,
             'feature': 'topography',
             's_enhance': s_enhance,
             't_enhance': 1,


### PR DESCRIPTION
Enable multiple source files for exo data and add `source_handler_kwargs` parameter, which can be used to specify how to combine the files with xarray. e.g. specify `source_files` as glob pattern and combine them with `source_handler_kwargs` = `{'res_kwargs': ...}`. This is motivated by wanting to accommodate having separate nc files for each madis network for observation conditioned models. This also enables adding observations without having to rewrite source files. 